### PR TITLE
Handle null reference before loop

### DIFF
--- a/routes_minimap.lua
+++ b/routes_minimap.lua
@@ -23,6 +23,7 @@ function dataProvider:RefreshAllData()
     
     local uiMapID = HBD:GetPlayerZone()
     if not uiMapID then return end
+    if not ns.points[uiMapID] then return end
 
     for coord, point in pairs(ns.points[uiMapID]) do
         if point.routes and ns.should_show_point(coord, point, uiMapID, true) then


### PR DESCRIPTION
There is a null reference happening with https://github.com/kemayo/wow-handynotes-dragonflight when loading addon in e.g. Orgrimmar for me. I fixed it locally by adding the proposed change 👍🏻  Feel free to merge it if it seems appropiate to you