### PR TITLE
Prevent errors from tooltip addons

### DIFF
--- a/handler.lua
+++ b/handler.lua
@@ -923,6 +923,7 @@ local function handle_tooltip(tooltip, point, skip_label)
         local comparison = _G[myname.."ComparisonTooltip"]
         if not comparison then
             comparison = CreateFrame("GameTooltip", myname.."ComparisonTooltip", UIParent, "ShoppingTooltipTemplate")
+            Mixin(comparison, GameTooltipDataMixin)
             comparison:SetFrameStrata("TOOLTIP")
             comparison:SetClampedToScreen(true)
         end


### PR DESCRIPTION
Some tooltip addons (incorrectly) assume that tooltip:GetUnit and friends always exist. The GameTooltipDataMixin adds those helpers to the comparison tooltip